### PR TITLE
Add mapping for PostGIS adapter

### DIFF
--- a/lib/active_record/hierarchical_query/adapters.rb
+++ b/lib/active_record/hierarchical_query/adapters.rb
@@ -10,6 +10,7 @@ module ActiveRecord
 
       ADAPTERS = Hash[
         :PostgreSQL => :PostgreSQL,
+        :PostGIS => :PostgreSQL,
         :OracleEnhanced => :Oracle
       ].stringify_keys
 


### PR DESCRIPTION
Adds a mapping for applicatiosn using the PostGIS adapter (an extension of PostgreSQL). 
