### PR TITLE
Add a select distinct option

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,12 @@ ORDER BY "categories__recursive"."__order_column" ASC
 
 If you want to use a `LEFT OUTER JOIN` instead of an `INNER JOIN`, add a query option for `outer_join_hierarchical`.   This option allows the query to return non-hierarchical entries:
 ```ruby
-.join_recursive(outer_join_hierarchical: true)
+  .join_recursive(outer_join_hierarchical: true)
+```
+
+If you want to `SELECT DISTINCT` values, add a query option for  `distinct`
+```ruby
+  .join_recursive(distinct: true)
 ```
 
 If, when joining the recursive view to the main table, you want to change the foreign_key on the recursive view from the primary key of the main table to another column:

--- a/README.md
+++ b/README.md
@@ -244,6 +244,17 @@ Category.join_recursive do |query|
 end
 ```
 
+## DISTINCT
+By default, the union term in the Common Table Expression uses a `UNION ALL`. If you want
+to `SELECT DISTINCT` CTE values, add a query option for  `distinct`
+```ruby
+Category.join_recursive do |query|
+  query.connect_by(id: :parent_id)
+       .start_with(id: node_1.id)
+       .distinct
+end
+```
+
 ## Generated SQL queries
 
 Under the hood this extensions builds `INNER JOIN` to recursive subquery.
@@ -298,11 +309,6 @@ ORDER BY "categories__recursive"."__order_column" ASC
 If you want to use a `LEFT OUTER JOIN` instead of an `INNER JOIN`, add a query option for `outer_join_hierarchical`.   This option allows the query to return non-hierarchical entries:
 ```ruby
   .join_recursive(outer_join_hierarchical: true)
-```
-
-If you want to `SELECT DISTINCT` values, add a query option for  `distinct`
-```ruby
-  .join_recursive(distinct: true)
 ```
 
 If, when joining the recursive view to the main table, you want to change the foreign_key on the recursive view from the primary key of the main table to another column:

--- a/lib/active_record/hierarchical_query/cte/query_builder.rb
+++ b/lib/active_record/hierarchical_query/cte/query_builder.rb
@@ -11,17 +11,15 @@ module ActiveRecord
       class QueryBuilder
         attr_reader :query,
                     :columns,
-                    :cycle_detector,
-                    :options
+                    :cycle_detector
 
         delegate :klass, :table, :recursive_table, to: :query
 
         # @param [ActiveRecord::HierarchicalQuery::Query] query
-        def initialize(query, options = {})
+        def initialize(query)
           @query = query
           @columns = Columns.new(@query)
           @cycle_detector = CycleDetector.new(@query)
-          @options = options
         end
 
         def bind_values
@@ -60,7 +58,7 @@ module ActiveRecord
         end
 
         def build_select
-          if @options[:distinct] == true
+          if @query.distinct_value == true
             @arel.project(recursive_table[Arel.star]).distinct
           else
             @arel.project(recursive_table[Arel.star])

--- a/lib/active_record/hierarchical_query/cte/query_builder.rb
+++ b/lib/active_record/hierarchical_query/cte/query_builder.rb
@@ -11,15 +11,17 @@ module ActiveRecord
       class QueryBuilder
         attr_reader :query,
                     :columns,
-                    :cycle_detector
+                    :cycle_detector,
+                    :options
 
         delegate :klass, :table, :recursive_table, to: :query
 
         # @param [ActiveRecord::HierarchicalQuery::Query] query
-        def initialize(query)
+        def initialize(query, options = {})
           @query = query
           @columns = Columns.new(@query)
           @cycle_detector = CycleDetector.new(@query)
+          @options = options
         end
 
         def bind_values
@@ -58,7 +60,11 @@ module ActiveRecord
         end
 
         def build_select
-          @arel.project(recursive_table[Arel.star])
+          if @options[:distinct] == true
+            @arel.project(recursive_table[Arel.star]).distinct
+          else
+            @arel.project(recursive_table[Arel.star])
+          end
         end
 
         def build_limits

--- a/lib/active_record/hierarchical_query/join_builder.rb
+++ b/lib/active_record/hierarchical_query/join_builder.rb
@@ -6,19 +6,19 @@ module ActiveRecord
       # @param [ActiveRecord::HierarchicalQuery::Query] query
       # @param [ActiveRecord::Relation] join_to
       # @param [#to_s] subquery_alias
-      def initialize(query, join_to, subquery_alias, join_options = {})
+      def initialize(query, join_to, subquery_alias, options = {})
         @query = query
-        @builder = CTE::QueryBuilder.new(query)
+        @builder = CTE::QueryBuilder.new(query, options)
         @relation = join_to
         @alias = Arel::Table.new(subquery_alias, ActiveRecord::Base)
-        @join_options = join_options
+        @options = options
       end
 
       def build
         # outer joins to include non-hierarchical entries if specified
         # default option when flag is not specified is to include only entries participating
         # in a hierarchy
-        join_sql = @join_options[:outer_join_hierarchical].present? ? outer_join.to_sql : inner_join.to_sql
+        join_sql = @options[:outer_join_hierarchical] == true ? outer_join.to_sql : inner_join.to_sql
         relation = @relation.joins(join_sql)
 
         # copy bound variables from inner subquery (remove duplicates)
@@ -59,7 +59,7 @@ module ActiveRecord
       end
 
       def custom_foreign_key
-        @join_options[:foreign_key]
+        @options[:foreign_key]
       end
 
       def foreign_key

--- a/lib/active_record/hierarchical_query/join_builder.rb
+++ b/lib/active_record/hierarchical_query/join_builder.rb
@@ -8,7 +8,7 @@ module ActiveRecord
       # @param [#to_s] subquery_alias
       def initialize(query, join_to, subquery_alias, options = {})
         @query = query
-        @builder = CTE::QueryBuilder.new(query, options)
+        @builder = CTE::QueryBuilder.new(query)
         @relation = join_to
         @alias = Arel::Table.new(subquery_alias, ActiveRecord::Base)
         @options = options
@@ -19,6 +19,7 @@ module ActiveRecord
         # default option when flag is not specified is to include only entries participating
         # in a hierarchy
         join_sql = @options[:outer_join_hierarchical] == true ? outer_join.to_sql : inner_join.to_sql
+
         relation = @relation.joins(join_sql)
 
         # copy bound variables from inner subquery (remove duplicates)

--- a/lib/active_record/hierarchical_query/query.rb
+++ b/lib/active_record/hierarchical_query/query.rb
@@ -20,7 +20,8 @@ module ActiveRecord
                   :limit_value,
                   :offset_value,
                   :order_values,
-                  :nocycle_value
+                  :nocycle_value,
+                  :distinct_value
 
       # @api private
       CHILD_SCOPE_METHODS = :where, :joins, :group, :having, :bind
@@ -36,6 +37,7 @@ module ActiveRecord
         @offset_value = nil
         @nocycle_value = false
         @order_values = []
+        @distinct_value = false
       end
 
       # Specify root scope of the hierarchy.
@@ -268,6 +270,14 @@ module ActiveRecord
       #   end
       def table
         @klass.arel_table
+      end
+
+      # Turn on select distinct option in the CTE.
+      #
+      # @return [ActiveRecord::HierarchicalQuery::Query] self
+      def distinct
+        @distinct_value = true
+        self
       end
 
       # @return [Arel::Nodes::Node]

--- a/spec/active_record/hierarchical_query_spec.rb
+++ b/spec/active_record/hierarchical_query_spec.rb
@@ -260,10 +260,9 @@ describe ActiveRecord::HierarchicalQuery do
     end
   end
 
-  describe ':distinct query option' do
-    subject { klass.join_recursive(distinct: value) { connect_by(id: :parent_id) }.to_sql }
+  describe ':distinct query method' do
+    subject { klass.join_recursive { connect_by(id: :parent_id).distinct }.to_sql }
 
-    let(:value) { true }
     let(:select) {
       /SELECT \"categories__recursive\"/
     }
@@ -272,23 +271,7 @@ describe ActiveRecord::HierarchicalQuery do
       expect(subject).to match /SELECT DISTINCT \"categories__recursive\"/
     end
 
-    context 'value is false' do
-      let(:value) { false }
-
-      it 'selects without using a distinct' do
-        expect(subject).to match select
-      end
-    end
-
-    context 'value is a string' do
-      let(:value) { 'foo' }
-
-      it 'selects without using a distinct' do
-        expect(subject).to match select
-      end
-    end
-
-    context 'key is absent' do
+    context 'distinct method is absent' do
       subject { klass.join_recursive { connect_by(id: :parent_id) }.to_sql }
 
       it 'selects without using a distinct' do


### PR DESCRIPTION
Adding an option to perform a select distinct on the Common Table Expression, which is useful when this table is created using an outer join.
