### PR TITLE
make updates for rails 5

### DIFF
--- a/activerecord-hierarchical_query.gemspec
+++ b/activerecord-hierarchical_query.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = %w(lib)
 
-  spec.add_dependency 'activerecord', '>= 3.1.0', '< 5.0.0'
+  spec.add_dependency 'activerecord', '>= 3.1.0', '<= 5.0.0.1'
 
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'rake', '~> 10.4.2'

--- a/lib/active_record/hierarchical_query/cte/query_builder.rb
+++ b/lib/active_record/hierarchical_query/cte/query_builder.rb
@@ -40,7 +40,7 @@ module ActiveRecord
 
         private
         def build_manager
-          @arel = Arel::SelectManager.new(table.engine).
+          @arel = Arel::SelectManager.new(Arel::Table.engine).
               with(:recursive, with_query).
               from(recursive_table)
         end

--- a/lib/active_record/hierarchical_query/join_builder.rb
+++ b/lib/active_record/hierarchical_query/join_builder.rb
@@ -11,7 +11,7 @@ module ActiveRecord
         @query = query
         @builder = CTE::QueryBuilder.new(query, options: options)
         @relation = join_to
-        @alias = Arel::Table.new(subquery_alias, ActiveRecord::Base)
+        @alias = Arel::Table.new(subquery_alias)
         @options = options
       end
 

--- a/lib/active_record/hierarchical_query/orderings.rb
+++ b/lib/active_record/hierarchical_query/orderings.rb
@@ -100,7 +100,7 @@ module ActiveRecord
       def order_column
         table = order_attribute.relation
 
-        if table.engine == ActiveRecord::Base
+        if Arel::Tabel.engine == ActiveRecord::Base
           columns =
             if table.engine.connection.respond_to?(:schema_cache)
               table.engine.connection.schema_cache.columns_hash(table.name)


### PR DESCRIPTION
some changes for rails 5. these are necessary because of the gem's usage of internal Arel methods