### PR TITLE
Fixes #join_recursive for models with an order clause in the default scope

### DIFF
--- a/lib/active_record/hierarchical_query/query.rb
+++ b/lib/active_record/hierarchical_query/query.rb
@@ -24,7 +24,7 @@ module ActiveRecord
                   :distinct_value
 
       # @api private
-      CHILD_SCOPE_METHODS = :where, :joins, :group, :having, :bind
+      CHILD_SCOPE_METHODS = :where, :joins, :group, :having, :bind, :reorder
 
       def initialize(klass)
         @klass = klass
@@ -179,6 +179,7 @@ module ActiveRecord
       # @!method group(*values)
       # @!method having(*conditions)
       # @!method bind(value)
+      # @!method reorder(value)
       CHILD_SCOPE_METHODS.each do |method|
         define_method(method) do |*args|
           @child_scope_value = @child_scope_value.public_send(method, *args)

--- a/spec/active_record/hierarchical_query_spec.rb
+++ b/spec/active_record/hierarchical_query_spec.rb
@@ -219,6 +219,25 @@ describe ActiveRecord::HierarchicalQuery do
       end
     end
 
+    context "with a model with a default order" do
+      let!(:root) { LinkedItem.create(name: 'Root') }
+      let!(:child_1) { LinkedItem.create(parent: root, name: 'Child 1') }
+      let!(:child_2) { LinkedItem.create(parent: child_1, name: 'Child 2') }
+      let!(:child_3) { LinkedItem.create(parent: child_1, name: 'Child 3') }
+      let!(:child_4) { LinkedItem.create(parent: root, name: 'Child 4') }
+      let!(:child_5) { LinkedItem.create(parent: child_4, name: 'Child 5') }
+
+      it "can use join_recursive despite the default order" do
+        parents =
+        expect(
+            LinkedItem.join_recursive do |query|
+              query.start_with(id: child_2.parent_id)
+                  .connect_by(parent_id: :id).reorder(nil)
+            end
+        ).to match_array([root, child_1])
+      end
+    end
+
     describe 'binding values' do
       it 'binds values' do
         expect(

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -13,4 +13,9 @@ ActiveRecord::Schema.define(version: 0) do
     t.column :category_id, :integer
     t.column :title, :string
   end
+
+  create_table :linked_items, force: true do |t|
+    t.column :parent_id, :integer
+    t.column :name, :string
+  end
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -42,3 +42,9 @@ end
 class Article < ActiveRecord::Base
   belongs_to :category
 end
+
+class LinkedItem < ActiveRecord::Base
+  belongs_to :parent, class_name: 'LinkedItem', foreign_key: :parent_id
+
+  default_scope -> { order('name ASC') }
+end


### PR DESCRIPTION
Hey,

I've been trying to use the gem for a model that uses an ``order`` statement in it's default scope like this:

```ruby
class LinkedItem < ActiveRecord::Base
  belongs_to :parent, class_name: 'LinkedItem', foreign_key: :parent_id

  default_scope -> { order('name ASC') }
end
```

This lead to queries as:

```sql
SELECT "linked_items".* FROM "linked_items" INNER JOIN (WITH RECURSIVE "linked_items__recursive" AS ( SELECT "linked_items"."id", "linked_items"."parent_id" FROM "linked_items" WHERE "linked_items"."id" = $1 UNION ALL SELECT "linked_items"."id", "linked_items"."parent_id" FROM "linked_items" INNER JOIN "linked_items__recursive" ON "linked_items__recursive"."parent_id" = "linked_items"."id"  ORDER BY name ASC ) SELECT "linked_items__recursive".* FROM "linked_items__recursive") AS "linked_items__recursive" ON "linked_items"."id" = "linked_items__recursive"."id"
```

which failed on PostgreSQL due to the ``ORDER BY name ASC`` part with this error:

```
ERROR:  ORDER BY in a recursive query is not implemented at character 404
```

This fixes the problem by allowing to add a ``reorder`` statement to the child scope.
