### PR TITLE
Discard default scope order from recursive query

### DIFF
--- a/lib/active_record/hierarchical_query/cte/non_recursive_term.rb
+++ b/lib/active_record/hierarchical_query/cte/non_recursive_term.rb
@@ -29,7 +29,8 @@ module ActiveRecord
           @scope ||= query.
               start_with_value.
               select(columns).
-              except(*DISALLOWED_CLAUSES)
+              except(*DISALLOWED_CLAUSES).
+              reorder(nil)
         end
 
         def columns

--- a/lib/active_record/hierarchical_query/cte/recursive_term.rb
+++ b/lib/active_record/hierarchical_query/cte/recursive_term.rb
@@ -25,7 +25,7 @@ module ActiveRecord
 
         private
         def scope
-          @scope ||= query.child_scope_value.select(columns)
+          @scope ||= query.child_scope_value.select(columns).reorder(nil)
         end
 
         def columns

--- a/spec/active_record/hierarchical_query_spec.rb
+++ b/spec/active_record/hierarchical_query_spec.rb
@@ -330,4 +330,22 @@ describe ActiveRecord::HierarchicalQuery do
       expect(result).to include(article)
     end
   end
+
+  describe 'Models with default scope' do
+    let!(:scoped_root) { ModelWithDefaultScope.create!(name: '9. Root') }
+    let!(:scoped_child_1) { ModelWithDefaultScope.create!(name: '8. Child', parent: scoped_root) }
+    let!(:scoped_child_2) { ModelWithDefaultScope.create!(name: '7. Child', parent: scoped_root) }
+
+    subject(:result) {
+      ModelWithDefaultScope.join_recursive do |query|
+        query
+          .connect_by(id: :parent_id)
+          .start_with(id: scoped_root.id)
+      end
+    }
+
+    it 'applies default scope to outer query without affecting recursive terms' do
+      expect(result).to eq [scoped_child_2, scoped_child_1, scoped_root]
+    end
+  end
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -13,4 +13,9 @@ ActiveRecord::Schema.define(version: 0) do
     t.column :category_id, :integer
     t.column :title, :string
   end
+
+  create_table :model_with_default_scopes, force: true do |t|
+    t.column :parent_id, :integer
+    t.column :name, :string
+  end
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -42,3 +42,9 @@ end
 class Article < ActiveRecord::Base
   belongs_to :category
 end
+
+class ModelWithDefaultScope < ActiveRecord::Base
+  belongs_to :parent, class_name: 'ModelWithDefaultScope'
+
+  default_scope -> { order('name ASC') }
+end


### PR DESCRIPTION
Given a model with default scope:
```
class LinkedItem < ActiveRecord::Base
  belongs_to :parent, class_name: 'LinkedItem', foreign_key: :parent_id
  default_scope -> { order('name ASC') }
end
```

When trying to build hierarchical query against this model
Builder applied default scope to recursive part of recursive query
which lead to invalid SQL queries:
```
SELECT "linked_items".* FROM "linked_items" INNER JOIN (WITH RECURSIVE "linked_items__recursive" AS ( SELECT "linked_items"."id", "linked_items"."parent_id" FROM "linked_items" WHERE "linked_items"."id" = $1 UNION ALL SELECT "linked_items"."id", "linked_items"."parent_id" FROM "linked_items" INNER JOIN "linked_items__recursive" ON "linked_items__recursive"."parent_id" = "linked_items"."id"  ORDER BY name ASC ) SELECT "linked_items__recursive".* FROM "linked_items__recursive") AS "linked_items__recursive" ON "linked_items"."id" = "linked_items__recursive"."id"
```

This commit removes any default ordering when applying default scope to
CTE terms.