### PR TITLE
Fix ordering by multiple columns

### DIFF
--- a/lib/active_record/hierarchical_query/orderings.rb
+++ b/lib/active_record/hierarchical_query/orderings.rb
@@ -27,12 +27,10 @@ module ActiveRecord
         order_values.each do |value|
           Array.wrap(as_orderings(value)).each do |ordering|
             @values << ordering
-
-            yield ordering
           end
         end
 
-        @values
+        @values.each(&block)
       end
 
       # Returns order expression to be inserted into SELECT clauses of both


### PR DESCRIPTION
The order expression to be inserted into the SELECT clauses of recursive and non-recursive terms included only the first attribute and the rest was being discarded.

Now, we first populate the order expressions into `@values` and then we call the block once for each element.