### PR TITLE
Update pg dependency to < 1.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in activerecord-hierarchical_query.gemspec
 gemspec
 
-gem 'pg', '>= 0.21', '< 1.5'
+gem 'pg', '>= 0.21', '< 1.6'
 gem 'activerecord', '>= 5.0', '< 7.1'
 
 group :local do

--- a/activerecord-hierarchical_query.gemspec
+++ b/activerecord-hierarchical_query.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w(lib)
 
   spec.add_dependency 'activerecord', '>= 5.0', '< 7.1'
-  spec.add_dependency 'pg', '>= 0.21', '< 1.5'
+  spec.add_dependency 'pg', '>= 0.21', '< 1.6'
 
   spec.add_development_dependency 'bundler', '>= 1.16'
   spec.add_development_dependency 'rake', '~> 12.3'


### PR DESCRIPTION
Hi,

This allows using pg 1.5. I tested this on my machine but did not set up Appraisals for multiple scenarios so hopefully you can run more tests.

If it all passes, would you be able to cut a gem release?

Thanks so much,
Justin